### PR TITLE
Schlick BSDF override verification with Metashade wrapper

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -128,6 +128,25 @@
             "options": {
                 "cwd": "${workspaceFolder}"
             }
+        },
+        {
+            "label": "Run MaterialXTest [genglsl]",
+            "type": "shell",
+            "command": "\"${workspaceFolder}/build/bin/Debug/MaterialXTest.exe\"",
+            "args": [
+                "[renderglsl]"
+            ],
+            "group": "test",
+            "problemMatcher": [],
+            "isBackground": false,
+            "dependsOn": "Build MaterialX Debug",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
         }
     ]
 }

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -21,7 +21,7 @@
 
     <!-- Comma separated list of target" specifiers to indicate which
          code generators to use. -->
-    <input name="targets" type="string" value="genglsl,genosl,genoslnetwork,genmdl,genessl,genmsl,genslang" />
+    <input name="targets" type="string" value="genglsl" />
 
     <!-- Check the count of number of implementations used for a given generator -->
     <input name="checkImplCount" type="boolean" value="true" />
@@ -59,7 +59,7 @@
     <input name="irradianceIBLPath" type="string" value="resources/Lights/irradiance/san_giuseppe_bridge.hdr" />
 
     <!-- List of extra library paths for generator and render tests -->
-    <input name="extraLibraryPaths" type="string" value="" />
+    <input name="extraLibraryPaths" type="string" value="python/External/metashade/tests/ref/mtlx" />
 
     <!-- List of document paths for render tests -->
     <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/convolution,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/pbrlib/surfaceshader,resources/Materials/TestSuite/nprlib,resources/Materials/TestSuite/pbrlib/bsdf" />
@@ -77,7 +77,7 @@
          Supports absolute paths or paths relative to the test working directory.
          The directory will be created if it doesn't exist.
     -->
-    <input name="outputDirectory" type="string" value="" />
+    <input name="outputDirectory" type="string" value="build/metashade_test_output" />
 
     <!-- Enable Perfetto tracing during render tests (requires MATERIALX_BUILD_TRACING).
          When enabled, generates .perfetto-trace files in outputDirectory.

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -21,7 +21,7 @@
 
     <!-- Comma separated list of target" specifiers to indicate which
          code generators to use. -->
-    <input name="targets" type="string" value="genglsl" />
+    <input name="targets" type="string" value="genglsl,genosl,genoslnetwork,genmdl,genessl,genmsl,genslang" />
 
     <!-- Check the count of number of implementations used for a given generator -->
     <input name="checkImplCount" type="boolean" value="true" />
@@ -77,7 +77,7 @@
          Supports absolute paths or paths relative to the test working directory.
          The directory will be created if it doesn't exist.
     -->
-    <input name="outputDirectory" type="string" value="build/metashade_test_output" />
+    <input name="outputDirectory" type="string" value="" />
 
     <!-- Enable Perfetto tracing during render tests (requires MATERIALX_BUILD_TRACING).
          When enabled, generates .perfetto-trace files in outputDirectory.

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -222,17 +222,6 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
     context.registerSourceCodeSearchPath(searchPath);
     context.registerSourceCodeSearchPath(searchPath.find("libraries/stdlib/genosl/include"));
 
-    // Register extra library paths as source code search paths so that
-    // wrapper GLSL files in extra libraries can resolve #include directives
-    // for standard library source files.
-    for (size_t i = 0; i < options.extraLibraryPaths.size(); i++)
-    {
-        context.registerSourceCodeSearchPath(options.extraLibraryPaths[i]);
-    }
-    // Also register the standard pbrlib genglsl source directory so that
-    // extra library wrappers can #include standard pbrlib GLSL files.
-    context.registerSourceCodeSearchPath(searchPath.find("libraries/pbrlib/genglsl"));
-
     // Set target unit space
     context.getOptions().targetDistanceUnit = "meter";
 

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -222,6 +222,17 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
     context.registerSourceCodeSearchPath(searchPath);
     context.registerSourceCodeSearchPath(searchPath.find("libraries/stdlib/genosl/include"));
 
+    // Register extra library paths as source code search paths so that
+    // wrapper GLSL files in extra libraries can resolve #include directives
+    // for standard library source files.
+    for (size_t i = 0; i < options.extraLibraryPaths.size(); i++)
+    {
+        context.registerSourceCodeSearchPath(options.extraLibraryPaths[i]);
+    }
+    // Also register the standard pbrlib genglsl source directory so that
+    // extra library wrappers can #include standard pbrlib GLSL files.
+    context.registerSourceCodeSearchPath(searchPath.find("libraries/pbrlib/genglsl"));
+
     // Set target unit space
     context.getOptions().targetDistanceUnit = "meter";
 

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -69,16 +69,19 @@ void ShaderRenderTester::loadDependentLibraries(GenShaderUtil::TestSuiteOptions 
 {
     dependLib = mx::createDocument();
 
-    mx::loadLibraries({ "libraries" }, searchPath, dependLib);
+    // Load extra libraries BEFORE standard libraries so that extra
+    // implementations take priority. NodeDef::getImplementation() returns
+    // the first matching target, using document insertion order.
     for (size_t i = 0; i < options.extraLibraryPaths.size(); i++)
     {
         const mx::FilePath& libraryPath = options.extraLibraryPaths[i];
         for (const mx::FilePath& libraryFile : libraryPath.getFilesInDirectory("mtlx"))
         {
-            std::cout << "Extra library path: " << (libraryPath / libraryFile).asString() << std::endl;
+            std::cout << "Extra library path (override): " << (libraryPath / libraryFile).asString() << std::endl;
             mx::loadLibrary((libraryPath / libraryFile), dependLib);
         }
     }
+    mx::loadLibraries({ "libraries" }, searchPath, dependLib);
 
     // Load any addition per renderer libraries
     loadAdditionalLibraries(dependLib, options);
@@ -218,6 +221,17 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
     mx::GenContext context(_shaderGenerator);
     context.registerSourceCodeSearchPath(searchPath);
     context.registerSourceCodeSearchPath(searchPath.find("libraries/stdlib/genosl/include"));
+
+    // Register extra library paths as source code search paths so that
+    // wrapper GLSL files in extra libraries can resolve #include directives
+    // for standard library source files.
+    for (size_t i = 0; i < options.extraLibraryPaths.size(); i++)
+    {
+        context.registerSourceCodeSearchPath(options.extraLibraryPaths[i]);
+    }
+    // Also register the standard pbrlib genglsl source directory so that
+    // extra library wrappers can #include standard pbrlib GLSL files.
+    context.registerSourceCodeSearchPath(searchPath.find("libraries/pbrlib/genglsl"));
 
     // Set target unit space
     context.getOptions().targetDistanceUnit = "meter";


### PR DESCRIPTION
## Summary

Enables MaterialXTest to verify that Metashade-generated implementations can override standard MaterialX node implementations. The Metashade wrapper for `generalized_schlick_bsdf` takes priority and is used during GLSL rendering tests.

**Companion Metashade PR:** [metashade/metashade#183](https://github.com/metashade/metashade/pull/183)

## Changes

### `source/MaterialXTest/MaterialXRender/RenderUtil.cpp`
- **Override-first library loading:** Load `extraLibraryPaths` before standard `libraries/` so Metashade implementations take precedence.
- **Source code search path registration:** Register `extraLibraryPaths` and `libraries/pbrlib/genglsl` as source code search paths so wrapper GLSL files can resolve `#include` directives for standard library source files.

### `resources/Materials/TestSuite/_options.mtlx`
- Changed `extraLibraryPaths` to relative path (`python/External/metashade/tests/ref/mtlx`).

### `.vscode/tasks.json`
- Added `Run MaterialXTest [genglsl]` task.

### `python/External/metashade` (submodule)
- Updated to merged main including [metashade/metashade#183](https://github.com/metashade/metashade/pull/183).

## Verification
- **815/815** GLSL rendering assertions pass
- Metashade wrapper confirmed present in generated GLSL output